### PR TITLE
SUBS 1223 store team profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.0.0-SNAPSHOT'
+version '2.1.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/uk/ac/ebi/subs/api/aap/TeamDto.java
+++ b/src/main/java/uk/ac/ebi/subs/api/aap/TeamDto.java
@@ -3,17 +3,12 @@ package uk.ac.ebi.subs.api.aap;
 import lombok.Builder;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
 @Data
 @Builder
 public class TeamDto {
 
     private String description;
 
-    @NotNull
-    @Size(min = 2, max = 500)
     private String centreName;
 
 }

--- a/src/main/java/uk/ac/ebi/subs/api/aap/TeamNameSequence.java
+++ b/src/main/java/uk/ac/ebi/subs/api/aap/TeamNameSequence.java
@@ -5,7 +5,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
- * Tracks the maximum number assigned for using
+ * Tracks the maximum number assigned for team names with a specific prefix
  */
 @Document
 @Data

--- a/src/main/java/uk/ac/ebi/subs/api/controllers/TeamSubmissionController.java
+++ b/src/main/java/uk/ac/ebi/subs/api/controllers/TeamSubmissionController.java
@@ -1,6 +1,5 @@
 package uk.ac.ebi.subs.api.controllers;
 
-import com.sun.xml.internal.bind.v2.TODO;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.event.AfterCreateEvent;
@@ -14,7 +13,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.method.P;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -31,7 +29,6 @@ import uk.ac.ebi.tsc.aap.client.model.Profile;
 import uk.ac.ebi.tsc.aap.client.repo.DomainService;
 import uk.ac.ebi.tsc.aap.client.repo.ProfileRepositoryRest;
 import uk.ac.ebi.tsc.aap.client.repo.ProfileService;
-import uk.ac.ebi.tsc.aap.client.repo.TokenService;
 
 import java.net.URI;
 import java.util.Collection;
@@ -75,21 +72,21 @@ public class TeamSubmissionController {
             @RequestHeader("Authorization") String authorizationHeader
     ) {
 
-        String token = authorizationHeader.replaceFirst("Bearer ","");
+        String token = authorizationHeader.replaceFirst("Bearer ", "");
         Collection<Domain> userDomains = domainService.getMyDomains(token);
         Optional<Domain> domainOptional = userDomains.stream().filter(d -> teamName.equals(d.getDomainName())).findAny();
 
-        if (!domainOptional.isPresent()){
+        if (!domainOptional.isPresent()) {
             System.out.println("domain not present");
             return ResponseEntity.unprocessableEntity().build(); //TODO make a better error response
         }
 
         Domain domain = domainOptional.get();
-        Profile profile = profileService.getDomainProfile(domain.getDomainReference(),token);
+        Profile profile = profileService.getDomainProfile(domain.getDomainReference(), token);
         Team team = new Team();
         team.setName(teamName);
-        team.setDescription( domain.getDomainDesc() );
-        team.setProfile( profile.getAttributes() );
+        team.setDescription(domain.getDomainDesc());
+        team.setProfile(profile.getAttributes());
 
 
         submission.setTeam(team);
@@ -98,7 +95,7 @@ public class TeamSubmissionController {
 
         Resource<Submission> resource = buildSubmissionResource(submission, savedSubmission);
 
-        HttpHeaders httpHeaders = buildHeaders(resource,savedSubmission);
+        HttpHeaders httpHeaders = buildHeaders(resource, savedSubmission);
 
         return buildResponseEntity(acceptHeader, resource, httpHeaders);
     }

--- a/src/main/java/uk/ac/ebi/subs/api/processors/TeamResourceProcessor.java
+++ b/src/main/java/uk/ac/ebi/subs/api/processors/TeamResourceProcessor.java
@@ -60,6 +60,7 @@ public class TeamResourceProcessor implements ResourceProcessor<Resource<Team>> 
                         .createTeamSubmission(
                                 resource.getContent().getName(),
                                 null,
+                                null,
                                 null
                         )
         ).withRel("submissions"+LinkHelper.CREATE_REL_SUFFIX)

--- a/src/test/java/uk/ac/ebi/subs/api/ApiIntegrationTestHelper.java
+++ b/src/test/java/uk/ac/ebi/subs/api/ApiIntegrationTestHelper.java
@@ -10,6 +10,7 @@ import com.mashape.unirest.http.utils.Base64Coder;
 import org.apache.http.HttpHeaders;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mockito.Mockito;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
@@ -19,8 +20,13 @@ import org.springframework.util.Assert;
 import uk.ac.ebi.subs.data.Submission;
 import uk.ac.ebi.subs.data.client.Sample;
 import uk.ac.ebi.subs.data.client.Study;
+import uk.ac.ebi.tsc.aap.client.model.Domain;
+import uk.ac.ebi.tsc.aap.client.model.Profile;
+import uk.ac.ebi.tsc.aap.client.repo.DomainService;
+import uk.ac.ebi.tsc.aap.client.repo.ProfileRepositoryRest;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -248,6 +254,23 @@ public class ApiIntegrationTestHelper {
 
     public Map<String, String> getPostHeaders() {
         return postHeaders;
+    }
+
+    public static void mockAapProfileAndDomain(DomainService domainService, ProfileRepositoryRest profileRepositoryRest){
+        Domain domain = new Domain();
+        domain.setDomainReference("1234");
+        domain.setDomainName(Helpers.TEAM_NAME);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("centre name", "An Institute");
+        Profile profile = new Profile(domain.getDomainReference(), null, domain, attributes);
+
+        Mockito.when(domainService.getMyDomains(Mockito.anyString()))
+                .thenReturn(Arrays.asList(
+                        domain
+                ));
+
+        Mockito.when(profileRepositoryRest.getDomainProfile(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(profile);
     }
 
 }

--- a/src/test/java/uk/ac/ebi/subs/api/SubmittableHandlerTest.java
+++ b/src/test/java/uk/ac/ebi/subs/api/SubmittableHandlerTest.java
@@ -21,6 +21,8 @@ import uk.ac.ebi.subs.repository.repos.status.SubmissionStatusRepository;
 import uk.ac.ebi.subs.repository.repos.submittables.SampleRepository;
 import uk.ac.ebi.subs.repository.repos.submittables.StudyRepository;
 import uk.ac.ebi.subs.validator.repository.ValidationResultRepository;
+import uk.ac.ebi.tsc.aap.client.repo.DomainService;
+import uk.ac.ebi.tsc.aap.client.repo.ProfileRepositoryRest;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -56,8 +58,9 @@ public class SubmittableHandlerTest {
     @Autowired
     private SubmittableValidationDispatcher submittableValidationDispatcher;
 
-    @MockBean
-    private RabbitMessagingTemplate rabbitMessagingTemplate;
+    @MockBean private RabbitMessagingTemplate rabbitMessagingTemplate;
+    @MockBean private DomainService domainService;
+    @MockBean private ProfileRepositoryRest profileRepositoryRest;
 
     @Before
     public void buildUp() {
@@ -72,6 +75,8 @@ public class SubmittableHandlerTest {
                 Arrays.asList(submissionRepository, sampleRepository, submissionStatusRepository),standardGetContentHeader,standardPostContentHeader);
 
         submittableValidationDispatcher.setRabbitMessagingTemplate(rabbitMessagingTemplate);
+
+        ApiIntegrationTestHelper.mockAapProfileAndDomain(domainService,profileRepositoryRest);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/subs/api/documentation/DocumentationHelper.java
+++ b/src/test/java/uk/ac/ebi/subs/api/documentation/DocumentationHelper.java
@@ -21,6 +21,9 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 public class DocumentationHelper {
 
+    public final static String AUTHORIZATION_HEADER_NAME = "Authorization";
+    public final static String AUTHORIZATION_HEADER_VALUE = "Bearer $TOKEN";
+
     protected static JUnitRestDocumentation jUnitRestDocumentation(){
         return new JUnitRestDocumentation("build/generated-snippets");
     }
@@ -84,7 +87,7 @@ public class DocumentationHelper {
     }
 
     protected static HeaderAddingPreprocessor addAuthTokenHeader(){
-        return DocumentationHelper.addHeader("Authorization","Bearer $TOKEN");
+        return DocumentationHelper.addHeader(AUTHORIZATION_HEADER_NAME,AUTHORIZATION_HEADER_VALUE);
     }
 
     protected static FieldDescriptor linksResponseField() {


### PR DESCRIPTION
We need to have team profile information available to the archive agents. We need to have the users AAP token to get this information, so we can't defer getting the information to the dispatcher or agent, we have to get it during a user request. This request adds the profile information when the submission is first created 