### PR TITLE
Subs 1297 privacy notice

### DIFF
--- a/src/docs/asciidoc/about.adoc
+++ b/src/docs/asciidoc/about.adoc
@@ -1,0 +1,18 @@
+= About
+:docinfo: shared
+
+== Team
+
+The EBI submission inteface is primarily developed by members of the Molecular Archive Resources cluster, lead
+by https://www.ebi.ac.uk/about/people/helen-parkinson[Helen Parkinson], in collaboration with groups across the
+institute.
+
+== Announcements
+
+If you use the submission interface regularly, or maintain software that interacts with it, you may want to keep up to
+date with any changes and improvements by subscribing to the
+[https://listserver.ebi.ac.uk/mailman/listinfo/submission-announce]announcement mailing list.
+
+== Privacy
+
+include::privacy-notice.adoc[]

--- a/src/docs/asciidoc/guides-list.adoc
+++ b/src/docs/asciidoc/guides-list.adoc
@@ -3,3 +3,4 @@
 * <<guide_overview.adoc#,Overview>>
 * <<guide_accounts_and_logging_in.adoc#,Setting up a user account and logging in>>
 * <<guide_getting_started.adoc#,Getting started>>
+* <<about.adoc#,About>>

--- a/src/docs/asciidoc/privacy-notice.adoc
+++ b/src/docs/asciidoc/privacy-notice.adoc
@@ -1,0 +1,2 @@
+This website and the API it describes require limited processing of personal data. For more information, please read our
+https://www.ebi.ac.uk/data-protection/privacy-notice/ebi-wide-submission[privacy policy].

--- a/src/docs/asciidoc/reference-list.adoc
+++ b/src/docs/asciidoc/reference-list.adoc
@@ -22,3 +22,4 @@ endif::assayData[]
 * <<ref_validation_results.adoc#,Validation results>>
 * <<ref_ui_support.adoc#,UI Support>>
 * <<ref_spreadsheets_and_templates.adoc#,Spreadsheets and templates>>
+* <<about.adoc#,About>>


### PR DESCRIPTION
Adding an about page with privacy notice link to the API docs. Note that the link is not expected to be live yet, pending review and publication by the DP/GDPR team.