### PR TITLE
sheet loading must trigger validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.21.0-SNAPSHOT'
+version '2.22.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/uk/ac/ebi/subs/api/sheetloader/SheetLoaderService.java
+++ b/src/main/java/uk/ac/ebi/subs/api/sheetloader/SheetLoaderService.java
@@ -143,17 +143,14 @@ public class SheetLoaderService {
 
         stopWatch.stop();
         stopWatch.start("validation trigger");
-        Optional<? extends StoredSubmittable> o = submittablesWithRows.stream()
+        submittablesWithRows.stream()
                 .filter(p -> p.getFirst().hasErrors() == false)
                 .map(p -> p.getSecond())
-                .findAny();
+                .forEach(submittable -> submittableValidationDispatcher.validateUpdate(submittable));
 
-        if (o.isPresent()) {
-            //this will trigger validation of everything in the submission
-            submittableValidationDispatcher.validateUpdate(o.get());
-        }
         stopWatch.stop();
         stopWatch.start("save progress");
+
 
         sheet.setStatus(SheetStatusEnum.Completed);
         sheet.setLastModifiedDate(new Date());


### PR DESCRIPTION
Previous version of sheet loading relied on indiscriminate chained
validation. We’re getting rid of that, so we need to trigger validation
for every submittable.