### PR TITLE
[SUBS-1584] Set data type id and entity type on the newly instantiated validation result

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.23.2-SNAPSHOT'
+version '2.23.3-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/uk/ac/ebi/subs/api/sheetloader/SheetBulkOps.java
+++ b/src/main/java/uk/ac/ebi/subs/api/sheetloader/SheetBulkOps.java
@@ -121,6 +121,8 @@ public class SheetBulkOps {
         ValidationResult validationResult = new ValidationResult();
         validationResult.setEntityUuid(storedSubmittable.getId());
         validationResult.setUuid(UUID.randomUUID().toString());
+        validationResult.setDataTypeId(storedSubmittable.getDataType().getId());
+        validationResult.setEntityType(storedSubmittable.getDataType().getSubmittableClassName());
 
         validationResult.setSubmissionId(storedSubmittable.getSubmission().getId());
 


### PR DESCRIPTION
The sheet loader service previously not set the data type id and entity type on their newly created validation result. This was causing a problem when the 'submission blockers' service was gathering data.