### PR TITLE
accession checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.23.4-SNAPSHOT'
+version '2.23.5-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/uk/ac/ebi/subs/api/services/UserAuthoritiesService.java
+++ b/src/main/java/uk/ac/ebi/subs/api/services/UserAuthoritiesService.java
@@ -14,7 +14,7 @@ public class UserAuthoritiesService {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
-            return Stream.of();
+            return Stream.empty();
         }
         return authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)

--- a/src/main/java/uk/ac/ebi/subs/api/services/UserAuthoritiesService.java
+++ b/src/main/java/uk/ac/ebi/subs/api/services/UserAuthoritiesService.java
@@ -1,0 +1,24 @@
+package uk.ac.ebi.subs.api.services;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+@Component
+public class UserAuthoritiesService {
+
+    public Stream<String> userAuthoritiesStream() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            return Stream.of();
+        }
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .map(a -> a.replaceFirst("ROLE_", ""))
+                ;
+    }
+}

--- a/src/main/java/uk/ac/ebi/subs/api/services/UserTeamService.java
+++ b/src/main/java/uk/ac/ebi/subs/api/services/UserTeamService.java
@@ -43,6 +43,9 @@ public class UserTeamService {
     @NonNull
     private ProfileService profileService;
 
+    @NonNull
+    private UserAuthoritiesService userAuthoritiesService;
+
     public List<Team> userTeams(String userToken) {
         // this collection of teams can contain teams that could already been deleted or created after the token created
         Collection<Domain> domains = domainService.getMyDomains(userToken);
@@ -83,14 +86,9 @@ public class UserTeamService {
     }
 
     public Stream<String> userTeamNamesStream() {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null) {
-            return Stream.of();
-        }
-        return authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .map(a -> a.replaceFirst("ROLE_", ""))
+        return userAuthoritiesService.userAuthoritiesStream()
                 .filter(a -> a.startsWith(teamNamePrefix));
     }
+
+
 }

--- a/src/main/java/uk/ac/ebi/subs/api/validators/CoreSubmittableValidationHelper.java
+++ b/src/main/java/uk/ac/ebi/subs/api/validators/CoreSubmittableValidationHelper.java
@@ -4,12 +4,10 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import uk.ac.ebi.subs.api.services.OperationControlService;
 import uk.ac.ebi.subs.api.services.UserAuthoritiesService;
-import uk.ac.ebi.subs.api.services.UserTeamService;
 import uk.ac.ebi.subs.repository.model.Checklist;
 import uk.ac.ebi.subs.repository.model.DataType;
 import uk.ac.ebi.subs.repository.model.StoredSubmittable;
@@ -45,8 +43,6 @@ public class CoreSubmittableValidationHelper {
     private static final String DATA_MIGRATION_DOMAIN_NAME = "embl-ebi-subs-data-migrator";
 
 
-
-
     public void validate(StoredSubmittable target, SubmittableRepository repository, Errors errors) {
         logger.debug("validating {}", target);
         StoredSubmittable storedVersion = null;
@@ -76,7 +72,7 @@ public class CoreSubmittableValidationHelper {
     /**
      * If an accession is provided, it should already be recorded in the database. If it is known, the team name,
      * alias and data type, must match.
-     *
+     * <p>
      * If the user is has the data migrator role, they can use an accession, even if USI don't know it
      *
      * @param target
@@ -102,16 +98,16 @@ public class CoreSubmittableValidationHelper {
             SubsApiErrors.inconsistent_with_previous_records.addError(errors, "alias");
         }
 
-        if (!accessionedRecord.getTeam().getName().equals(target.getTeam().getName())){
+        if (!accessionedRecord.getTeam().getName().equals(target.getTeam().getName())) {
             SubsApiErrors.inconsistent_with_previous_records.addError(errors, "team.name");
         }
 
-        if (!accessionedRecord.getDataType().equals(target.getDataType())){
+        if (!accessionedRecord.getDataType().equals(target.getDataType())) {
             SubsApiErrors.inconsistent_with_previous_records.addError(errors, "dataType");
         }
     }
 
-    private boolean userIsDataMigrator(){
+    private boolean userIsDataMigrator() {
         return userAuthoritiesService.userAuthoritiesStream().anyMatch(DATA_MIGRATION_DOMAIN_NAME::equals);
     }
 

--- a/src/main/java/uk/ac/ebi/subs/api/validators/CoreSubmittableValidationHelper.java
+++ b/src/main/java/uk/ac/ebi/subs/api/validators/CoreSubmittableValidationHelper.java
@@ -1,21 +1,18 @@
 package uk.ac.ebi.subs.api.validators;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
 import uk.ac.ebi.subs.api.services.OperationControlService;
-import uk.ac.ebi.subs.data.status.ProcessingStatusEnum;
-import uk.ac.ebi.subs.data.submittable.Submittable;
+import uk.ac.ebi.subs.api.services.UserAuthoritiesService;
+import uk.ac.ebi.subs.api.services.UserTeamService;
 import uk.ac.ebi.subs.repository.model.Checklist;
 import uk.ac.ebi.subs.repository.model.DataType;
-import uk.ac.ebi.subs.repository.model.ProcessingStatus;
 import uk.ac.ebi.subs.repository.model.StoredSubmittable;
-import uk.ac.ebi.subs.repository.model.Study;
-import uk.ac.ebi.subs.repository.repos.status.ProcessingStatusRepository;
 import uk.ac.ebi.subs.repository.repos.submittables.SubmittableRepository;
 
 import java.util.Arrays;
@@ -35,22 +32,27 @@ import java.util.stream.Stream;
  * status code instead of a 400 (bad request)
  */
 @Component
+@RequiredArgsConstructor
 public class CoreSubmittableValidationHelper {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    @NonNull
     private OperationControlService operationControlService;
 
-    @Autowired
-    public CoreSubmittableValidationHelper(OperationControlService operationControlService) {
-        this.operationControlService = operationControlService;
-    }
+    @NonNull
+    private UserAuthoritiesService userAuthoritiesService;
+
+    private static final String DATA_MIGRATION_DOMAIN_NAME = "embl-ebi-subs-data-migrator";
+
+
+
 
     public void validate(StoredSubmittable target, SubmittableRepository repository, Errors errors) {
         logger.debug("validating {}", target);
         StoredSubmittable storedVersion = null;
 
-        SubsApiErrors.rejectIfEmptyOrWhitespace(errors,"submission");
-        SubsApiErrors.rejectIfEmptyOrWhitespace(errors,"dataType");
+        SubsApiErrors.rejectIfEmptyOrWhitespace(errors, "submission");
+        SubsApiErrors.rejectIfEmptyOrWhitespace(errors, "dataType");
 
         ensureChecklistIsForSameDataTypeAsSubmittable(target, errors);
 
@@ -62,11 +64,55 @@ public class CoreSubmittableValidationHelper {
             storedVersion = repository.findOne(target.getId());
         }
 
-        this.validateAlias(target,repository,errors);
+        this.validateAlias(target, repository, errors);
 
         this.validate(target, storedVersion, errors);
 
-        this.validateAliasIsLockedToDataType(target,repository,errors);
+        this.validateAliasIsLockedToDataType(target, repository, errors);
+
+        this.validateAccessionIsKnown(target, repository, errors);
+    }
+
+    /**
+     * If an accession is provided, it should already be recorded in the database. If it is known, the team name,
+     * alias and data type, must match.
+     *
+     * If the user is has the data migrator role, they can use an accession, even if USI don't know it
+     *
+     * @param target
+     * @param repository
+     * @param errors
+     */
+    private void validateAccessionIsKnown(StoredSubmittable target, SubmittableRepository repository, Errors errors) {
+
+        if (target.getAccession() == null) {
+            return;
+        }
+
+        StoredSubmittable accessionedRecord = repository.findFirstByAccessionOrderByCreatedDateDesc(target.getAccession());
+
+        if (accessionedRecord == null) {
+            if (!userIsDataMigrator()) {
+                SubsApiErrors.unknown_accession.addError(errors, "accession");
+            }
+            return;
+        }
+
+        if (!accessionedRecord.getAlias().equals(target.getAlias())) {
+            SubsApiErrors.inconsistent_with_previous_records.addError(errors, "alias");
+        }
+
+        if (!accessionedRecord.getTeam().getName().equals(target.getTeam().getName())){
+            SubsApiErrors.inconsistent_with_previous_records.addError(errors, "team.name");
+        }
+
+        if (!accessionedRecord.getDataType().equals(target.getDataType())){
+            SubsApiErrors.inconsistent_with_previous_records.addError(errors, "dataType");
+        }
+    }
+
+    private boolean userIsDataMigrator(){
+        return userAuthoritiesService.userAuthoritiesStream().anyMatch(DATA_MIGRATION_DOMAIN_NAME::equals);
     }
 
     private void ensureChecklistIsForSameDataTypeAsSubmittable(StoredSubmittable target, Errors errors) {
@@ -74,14 +120,14 @@ public class CoreSubmittableValidationHelper {
         Checklist checklist = target.getChecklist();
 
         if (dataType != null && checklist != null
-                && !dataType.getId().equals( checklist.getDataTypeId())){
-            SubsApiErrors.invalid.addError(errors,"checklist");
+                && !dataType.getId().equals(checklist.getDataTypeId())) {
+            SubsApiErrors.invalid.addError(errors, "checklist");
         }
     }
 
     public void validateAlias(StoredSubmittable target, SubmittableRepository repository, Errors errors) {
 
-        SubsApiErrors.rejectIfEmptyOrWhitespace(errors,"alias");
+        SubsApiErrors.rejectIfEmptyOrWhitespace(errors, "alias");
         validateOnlyUseOfAliasInSubmission(target, repository, errors);
     }
 

--- a/src/main/java/uk/ac/ebi/subs/api/validators/SubsApiErrors.java
+++ b/src/main/java/uk/ac/ebi/subs/api/validators/SubsApiErrors.java
@@ -14,12 +14,14 @@ import org.springframework.validation.ValidationUtils;
 public enum SubsApiErrors {
 
     not_a_subs_team("Submissions must be owned by a 'subs.' team"),
-    missing_alias("Each entry must have an alias/unique name filled in"),
+    missing_alias("Each entry must have an alias"),
     missing_field("This required field has not been set"),
+    unknown_accession("You have provided an accession, but we do not have a record of it."),
+    inconsistent_with_previous_records("The value of this field conflicts with earlier submissions"),
     invalid("The formatting of this field is invalid"),
     resource_locked("The resource cannot be changed"),
     already_exists("Another resource with the same value already exists"),
-    already_exists_and_not_completed("Another resource with the same alias already exists within the team and is not 'Completed'."),
+
     file_is_not_in_deletable_status("The file is currently not in a deletable status."),
     missing_profile_attribute("The team profile is missing a required attribute.");
 

--- a/src/test/java/uk/ac/ebi/subs/api/CoreValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/subs/api/CoreValidatorTest.java
@@ -131,11 +131,6 @@ public class CoreValidatorTest {
         assertThat(error.getDefaultMessage(),is(equalTo(SubsApiErrors.already_exists.name())));
     }
 
-
-
-
-
-
     private Sample createSampleWithAlias(String alias) {
         Sample sample = new Sample();
         sample.setAlias(alias);

--- a/src/test/java/uk/ac/ebi/subs/api/services/UserTeamServiceTest.java
+++ b/src/test/java/uk/ac/ebi/subs/api/services/UserTeamServiceTest.java
@@ -37,11 +37,14 @@ public class UserTeamServiceTest {
     @MockBean
     private ProfileService profileService;
 
+    @MockBean
+    private UserAuthoritiesService userAuthoritiesService;
+
     private static final String USER_TOKEN = "JWT.ABC.123";
 
     @Before
     public void setup() {
-        userTeamService = new UserTeamService(domainService, profileService);
+        userTeamService = new UserTeamService(domainService, profileService, userAuthoritiesService);
         userTeamService.setTeamNamePrefix("subs.");
     }
 


### PR DESCRIPTION
accessions should normally only be provided if USI already knows about
them. If accessions are provided, identity details should match with
the known records.