### PR TITLE
[SUBS-1720] Move submittable persistence to subs-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.27.0-SNAPSHOT'
+version '2.27.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -48,6 +48,7 @@ dependencies {
     compile("com.fasterxml.jackson.module:jackson-module-afterburner:2.7.1")
     compile("org.apache.commons:commons-csv:1.5")
     compile("de.siegmar:logback-gelf:1.1.0")
+    compile("org.springframework.boot:spring-boot-devtools")
 
     testCompile("junit:junit")
     testCompile("org.springframework.boot:spring-boot-starter-test"){

--- a/src/main/java/uk/ac/ebi/subs/api/handlers/CoreSubmittableEventHandler.java
+++ b/src/main/java/uk/ac/ebi/subs/api/handlers/CoreSubmittableEventHandler.java
@@ -16,9 +16,12 @@ import uk.ac.ebi.subs.messaging.Exchanges;
 import uk.ac.ebi.subs.repository.model.ProcessingStatus;
 import uk.ac.ebi.subs.repository.model.StoredSubmittable;
 import uk.ac.ebi.subs.repository.repos.status.ProcessingStatusRepository;
+import uk.ac.ebi.subs.repository.repos.submittables.SubmittableRepository;
 import uk.ac.ebi.subs.repository.services.SubmittableHelperService;
 import uk.ac.ebi.subs.validator.data.ValidationResult;
 import uk.ac.ebi.subs.validator.repository.ValidationResultRepository;
+
+import java.util.Map;
 
 /**
  * This class responsible for handling Spring framework specific events
@@ -40,6 +43,9 @@ public class CoreSubmittableEventHandler {
 
     @NonNull
     private ProcessingStatusRepository processingStatusRepository;
+
+    @NonNull
+    private Map<Class<? extends StoredSubmittable>, SubmittableRepository<? extends StoredSubmittable>> submittableRepositoryMap;
 
     public final static String STORED_SUBMITTABLE_DELETION_ROUTING_KEY = "usi.submittable.deletion";
 
@@ -65,6 +71,10 @@ public class CoreSubmittableEventHandler {
     public void validateOnCreate(StoredSubmittable storedSubmittable) {
         /* Actions here should be also made in SheetLoader Service */
         submittableHelperService.processingStatusAndValidationResultSetUp(storedSubmittable);
+
+        SubmittableRepository repository = submittableRepositoryMap.get(storedSubmittable.getClass());
+        repository.save(storedSubmittable);
+
         submittableValidationDispatcher.validateCreate(storedSubmittable);
     }
 

--- a/src/test/java/uk/ac/ebi/subs/api/handlers/CoreSubmittableEventHandlerTest.java
+++ b/src/test/java/uk/ac/ebi/subs/api/handlers/CoreSubmittableEventHandlerTest.java
@@ -11,9 +11,13 @@ import uk.ac.ebi.subs.api.services.SubmittableValidationDispatcher;
 import uk.ac.ebi.subs.api.utils.SubmittableHelper;
 import uk.ac.ebi.subs.messaging.Exchanges;
 import uk.ac.ebi.subs.repository.model.AssayData;
+import uk.ac.ebi.subs.repository.model.StoredSubmittable;
 import uk.ac.ebi.subs.repository.repos.status.ProcessingStatusRepository;
+import uk.ac.ebi.subs.repository.repos.submittables.SubmittableRepository;
 import uk.ac.ebi.subs.repository.services.SubmittableHelperService;
 import uk.ac.ebi.subs.validator.repository.ValidationResultRepository;
+
+import java.util.Map;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -36,7 +40,8 @@ public class CoreSubmittableEventHandlerTest {
     private SubmittableValidationDispatcher submittableValidationDispatcher;
     @MockBean
     private ProcessingStatusRepository processingStatusRepository;
-
+    @MockBean
+    private Map<Class<? extends StoredSubmittable>, SubmittableRepository<? extends StoredSubmittable>> submittableRepositoryMap;
 
     @Before
     public void buildUp() {
@@ -45,7 +50,8 @@ public class CoreSubmittableEventHandlerTest {
                 submittableHelperService,
                 submittableValidationDispatcher,
                 validationResultRepository,
-                processingStatusRepository
+                processingStatusRepository,
+                submittableRepositoryMap
         );
     }
 


### PR DESCRIPTION
Refactor ProcessingStatus creation to not hide the submittable entity update with processing status into the repository method.
There will be more commits related to this in subs-repository and subs-api.