### PR TITLE
[Subs 1791] Fix api doc examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.30.1'
+version '2.30.2'
 
 
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.30.1-SNAPSHOT'
+version '2.30.1'
 
 
 apply plugin: 'java'

--- a/src/docs/asciidoc/guide_accounts_and_logging_in.adoc
+++ b/src/docs/asciidoc/guide_accounts_and_logging_in.adoc
@@ -51,7 +51,7 @@ NOTE: The token is valid for 1 hour.
 
 == How to use the obtained token
 
-You need to add this token as an `Authorization` header to all of your API requests.
+IMPORTANT: You need to add this token as an `Authorization` header to all of your API requests.
 The format is `Authorization: Bearer $TOKEN`
 
 === Example request
@@ -62,6 +62,7 @@ The format is `Authorization: Bearer $TOKEN`
 == Don't copy and paste your token
 
 You don't need to copy and paste the token. It's easier to write to an environment variable, such as in this example:
+
 [source,bash,subs={markup-in-source}]
 ----
 $ curl -u <your_aap_username>:<your_aap_password> {aapServerAPIRootURL}/auth > aap.jwt
@@ -72,7 +73,10 @@ NOTE: If you don't login successfully, there will be an error message in `aap.jw
 
 You can then use the environment variable like this:
 
+[source,bash]
+----
  $ curl -i -X GET -H "Accept: application/hal+json" -H "Content-Type: application/hal+json" -H "Authorization: Bearer $TOKEN" https://submissionexampleurl.test.com/api/teams
+----
 
 Be careful with your token; anyone with it can act as if they are you.
 
@@ -156,7 +160,7 @@ Once you have both identifiers, you can add the user to the team.
 
 [source,bash,subs={markup-in-source}]
 ----
- $ curl '{aapServerAPIRootURL}/domains/<your_domain_reference>/<your_user_reference>/user' -i -X PUT -H 'Authorization: Bearer $TOKEN' -H 'Accept: application/hal+json'
+ $ curl '{aapServerAPIRootURL}/domains/<your_domain_reference>/<your_user_reference>/user' -i -X PUT -H "Authorization: Bearer $TOKEN" -H 'Accept: application/hal+json'
 ----
 
 ===== Example response

--- a/src/docs/asciidoc/guide_file_upload.adoc
+++ b/src/docs/asciidoc/guide_file_upload.adoc
@@ -20,7 +20,7 @@ Use the command line interface of https://github.com/cenkalti/tus.py[tus.py] to 
 
 [source,bash,subs={markup-in-source}]
 ----
-tus-upload --chunk-size 1024000 --metadata name <destination_file_name.cram> --metadata submissionID '<your_submission_id>' --metadata jwtToken ‘<your_jwt_token>' <source_test_filename> {file_upload_server_url}
+tus-upload --chunk-size 1024000 --metadata name <destination_file_name.cram> --metadata submissionID '<your_submission_id>' --metadata jwtToken ‘<your_jwt_token>' '<source_test_filename>' {file_upload_server_url}
 ----
 
 What the parameters mean:

--- a/src/docs/asciidoc/ref_file_upload.adoc
+++ b/src/docs/asciidoc/ref_file_upload.adoc
@@ -11,7 +11,7 @@
 
 [source,bash,subs={markup-in-source}]
 ----
-tus-upload --chunk-size 1024000 --metadata name <destination_file_name.cram> --metadata submissionID '<your_submission_id>' --metadata jwtToken ‘<your_jwt_token>' <source_test_filename> {file_upload_server_url}
+tus-upload --chunk-size 1024000 --metadata name <destination_file_name.cram> --metadata submissionID '<your_submission_id>' --metadata jwtToken ‘<your_jwt_token>' '<source_test_filename>' {file_upload_server_url}
 ----
 
 Where the parameters are:

--- a/src/docs/asciidoc/ref_spreadsheets_and_templates.adoc
+++ b/src/docs/asciidoc/ref_spreadsheets_and_templates.adoc
@@ -82,7 +82,8 @@ NOTE: If using curl, you can use the --data-binary parameter to pass file conten
 
 [source,bash]
 ----
-$ curl 'https://submission-dev.ebi.ac.uk/api/submissions/faa8fbef-3f95-4363-bc78-a0c3ccb56a81/spreadsheet?checklistId=simple-sample-template' -i -X POST -H 'Content-Type: text/csv' -H 'Accept: application/hal+json' -H 'Authorization: Bearer TOKEN' --data-binary @my-samples.csv
+$ curl 'https://submission-dev.ebi.ac.uk/api/submissions/faa8fbef-3f95-4363-bc78-a0c3ccb56a81/spreadsheet?checklistId=simple-sample-template' -i
+-X POST -H 'Content-Type: text/csv' -H 'Accept: application/hal+json' -H "Authorization: Bearer $TOKEN" --data-binary @my-samples.csv
 ----
 
 ==== Response

--- a/src/test/java/uk/ac/ebi/subs/api/documentation/DocumentationHelper.java
+++ b/src/test/java/uk/ac/ebi/subs/api/documentation/DocumentationHelper.java
@@ -42,7 +42,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 public class DocumentationHelper {
 
     public final static String AUTHORIZATION_HEADER_NAME = "Authorization";
-    public final static String AUTHORIZATION_HEADER_VALUE = "Bearer TOKEN";
+    public final static String AUTHORIZATION_HEADER_VALUE = "Bearer '\"$TOKEN\"'";
 
     protected static JUnitRestDocumentation jUnitRestDocumentation(){
         return new JUnitRestDocumentation("build/generated-snippets");

--- a/src/test/java/uk/ac/ebi/subs/api/documentation/TeamDocumentation.java
+++ b/src/test/java/uk/ac/ebi/subs/api/documentation/TeamDocumentation.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,7 +24,6 @@ import uk.ac.ebi.subs.DocumentationProducer;
 import uk.ac.ebi.subs.api.Helpers;
 import uk.ac.ebi.subs.api.aap.TeamCreationService;
 import uk.ac.ebi.subs.api.aap.TeamDto;
-import uk.ac.ebi.subs.api.services.UserTeamService;
 import uk.ac.ebi.subs.data.component.Team;
 import uk.ac.ebi.tsc.aap.client.model.Domain;
 import uk.ac.ebi.tsc.aap.client.model.Profile;
@@ -48,8 +46,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.ac.ebi.subs.api.documentation.DocumentationHelper.addAuthTokenHeader;
 
-import static org.mockito.Mockito.when;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ApiApplication.class)
 @Category(DocumentationProducer.class)
@@ -65,9 +61,6 @@ public class TeamDocumentation {
     private int port;
     @Value("${usi.docs.scheme:http}")
     private String scheme;
-
-    private final String fakeToken = "TOKEN";
-    private final String fakeAuthHeader = "Bearer "+fakeToken;
 
     @Autowired
     private WebApplicationContext context;
@@ -198,7 +191,7 @@ public class TeamDocumentation {
 
         this.mockMvc.perform(
                 get("/api/user/teams")
-                        .header("Authorization",this.fakeAuthHeader)
+                        .header(DocumentationHelper.AUTHORIZATION_HEADER_NAME, DocumentationHelper.AUTHORIZATION_HEADER_VALUE)
                         .accept(RestMediaTypes.HAL_JSON)
         ).andExpect(status().isOk())
                 .andDo(


### PR DESCRIPTION
Changes:
- Fix the "Authorization" header appearance in our API documentation
- Fix small documentation issue in the file-upload section